### PR TITLE
Migrate to Conversations API

### DIFF
--- a/spec/api_spec.cr
+++ b/spec/api_spec.cr
@@ -118,33 +118,74 @@ describe Slack::API do
     api = Slack::API.new "some_token"
 
     json = %({
-                "id": "C1RDH5HPE",
-                "name": "fun",
-                "created": 1360782804,
-                "creator": "U024BE7LH",
-                "is_archived": false,
-                "is_member": false,
-                "topic": {
-                    "value": "Fun times",
-                    "creator": "U024BE7LV",
-                    "last_set": 1369677212
-                },
-                "purpose": {
-                    "value": "This channel is for fun",
-                    "creator": "U024BE7LH",
-                    "last_set": 1360782804
-                }
-            })
+      "id": "C012AB3CD",
+      "name": "general",
+      "is_channel": true,
+      "is_group": false,
+      "is_im": false,
+      "created": 1449252889,
+      "creator": "W012A3BCD",
+      "is_archived": false,
+      "is_general": true,
+      "unlinked": 0,
+      "name_normalized": "general",
+      "is_read_only": false,
+      "is_shared": false,
+      "parent_conversation": null,
+      "is_ext_shared": false,
+      "is_org_shared": false,
+      "pending_shared": [],
+      "is_pending_ext_shared": false,
+      "is_member": true,
+      "is_private": false,
+      "is_mpim": false,
+      "last_read": "1502126650.228446",
+      "topic": {
+          "value": "For public discussion of generalities",
+          "creator": "W012A3BCD",
+          "last_set": 1449709364
+      },
+      "purpose": {
+          "value": "This part of the workspace is for fun. Make fun here.",
+          "creator": "W012A3BCD",
+          "last_set": 1449709364
+      },
+      "previous_names": [
+          "specifics",
+          "abstractions",
+          "etc"
+      ],
+      "locale": "en-US"
+    })
 
-    WebMock.stub(:get, "https://slack.com/api/channels.info?token=some_token&channel=C1RDH5HPE")
+    relevant_fields_json = %({
+      "id": "C012AB3CD",
+      "name": "general",
+      "created": 1449252889,
+      "creator": "W012A3BCD",
+      "is_archived": false,
+      "is_member": true,
+      "topic": {
+          "value": "For public discussion of generalities",
+          "creator": "W012A3BCD",
+          "last_set": 1449709364
+      },
+      "purpose": {
+          "value": "This part of the workspace is for fun. Make fun here.",
+          "creator": "W012A3BCD",
+          "last_set": 1449709364
+      }
+    })
+
+    WebMock.stub(:get, "https://slack.com/api/conversations.info?token=some_token&channel=C012AB3CD")
            .to_return(body: %({
           "ok": true,
           "channel": #{json}
         }))
 
-    channel = api.channel_info("C1RDH5HPE")
+    channel = api.channel_info("C012AB3CD")
 
-    JSON.parse(channel.to_json).should eq(JSON.parse(json))
+    JSON.parse(channel.to_json).should eq(JSON.parse(relevant_fields_json))
   end
 
   it "posts to a channel" do

--- a/spec/api_spec.cr
+++ b/spec/api_spec.cr
@@ -45,36 +45,73 @@ describe Slack::API do
     api = Slack::API.new "some_token"
 
     json = %({
-                "id": "C024BE91L",
-                "name": "fun",
-                "created": 1360782804,
-                "creator": "U024BE7LH",
-                "is_archived": false,
-                "is_member": false,
-                "num_members": 6,
-                "topic": {
-                    "value": "Fun times",
-                    "creator": "U024BE7LV",
-                    "last_set": 1369677212
-                },
-                "purpose": {
-                    "value": "This channel is for fun",
-                    "creator": "U024BE7LH",
-                    "last_set": 1360782804
-                }
-            })
+      "id": "C012AB3CD",
+      "name": "general",
+      "is_channel": true,
+      "is_group": false,
+      "is_im": false,
+      "created": 1449252889,
+      "creator": "U012A3CDE",
+      "is_archived": false,
+      "is_general": true,
+      "unlinked": 0,
+      "name_normalized": "general",
+      "is_shared": false,
+      "is_ext_shared": false,
+      "is_org_shared": false,
+      "pending_shared": [],
+      "is_pending_ext_shared": false,
+      "is_member": true,
+      "is_private": false,
+      "is_mpim": false,
+      "topic": {
+          "value": "Company-wide announcements and work-based matters",
+          "creator": "",
+          "last_set": 0
+      },
+      "purpose": {
+          "value": "This channel is for team-wide communication and announcements. All team members are in this channel.",
+          "creator": "",
+          "last_set": 0
+      },
+      "previous_names": [],
+      "num_members": 4
+    })
 
-    WebMock.stub(:get, "https://slack.com/api/channels.list?token=some_token")
+    relevant_fields_json = %({
+      "id": "C012AB3CD",
+      "name": "general",
+      "created": 1449252889,
+      "creator": "U012A3CDE",
+      "is_archived": false,
+      "is_member": true,
+      "num_members": 4,
+      "topic": {
+          "value": "Company-wide announcements and work-based matters",
+          "creator": "",
+          "last_set": 0
+      },
+      "purpose": {
+          "value": "This channel is for team-wide communication and announcements. All team members are in this channel.",
+          "creator": "",
+          "last_set": 0
+      }
+    })
+
+    WebMock.stub(:get, "https://slack.com/api/conversations.list?token=some_token")
            .to_return(body: %({
           "ok": true,
-          "channels": [#{json}]
+          "channels": [#{json}],
+          "response_metadata": {
+            "next_cursor": "dGVhbTpDMDYxRkE1UEI="
+          }
         }))
 
     channels = api.channels
     channels.size.should eq(1)
 
     channel = channels[0]
-    JSON.parse(channel.to_json).should eq(JSON.parse(json))
+    JSON.parse(channel.to_json).should eq(JSON.parse(relevant_fields_json))
   end
 
   it "gets a channel's details" do

--- a/src/slack/api.cr
+++ b/src/slack/api.cr
@@ -12,7 +12,7 @@ class Slack::API
   end
 
   def channel_info(channel_id)
-    get_json "/api/channels.info", "channel", Channel, { "channel" => channel_id }
+    get_json "/api/conversations.info", "channel", Channel, { "channel" => channel_id }
   end
 
   def post_message(text : String, channel : String)

--- a/src/slack/api.cr
+++ b/src/slack/api.cr
@@ -8,7 +8,7 @@ class Slack::API
   end
 
   def channels
-    get_json "/api/channels.list", "channels", Array(Channel)
+    get_json "/api/conversations.list", "channels", Array(Channel)
   end
 
   def channel_info(channel_id)


### PR DESCRIPTION
Slack [just deprecated](https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api) the old `channel.*` APIs that we're using to list channels, so this PR moves our code (in a backwards-compatible way) to the new Conversations API.

Consumers shouldn't notice any difference.