### PR TITLE
Adds support for Crystal 0.36 and up. Moves to JSON::Serializable.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,9 @@ version: 0.10.1
 authors:
   - Ary Borenszweig <aborenszweig@manas.com.ar>
 
+crystal: ">= 0.36.1"
+
 development_dependencies:
   webmock:
     github: manastech/webmock.cr
-    version: "~> 0.12.1"
+    version: "~> 0.14.0"

--- a/spec/api_spec.cr
+++ b/spec/api_spec.cr
@@ -29,7 +29,7 @@ describe Slack::API do
             })
 
     WebMock.stub(:get, "https://slack.com/api/users.list?token=some_token")
-           .to_return(body: %({
+      .to_return(body: %({
           "ok": true,
           "members": [#{json}]
         }))
@@ -99,7 +99,7 @@ describe Slack::API do
     })
 
     WebMock.stub(:get, "https://slack.com/api/conversations.list?token=some_token")
-           .to_return(body: %({
+      .to_return(body: %({
           "ok": true,
           "channels": [#{json}],
           "response_metadata": {
@@ -178,7 +178,7 @@ describe Slack::API do
     })
 
     WebMock.stub(:get, "https://slack.com/api/conversations.info?token=some_token&channel=C012AB3CD")
-           .to_return(body: %({
+      .to_return(body: %({
           "ok": true,
           "channel": #{json}
         }))
@@ -206,7 +206,7 @@ describe Slack::API do
     })
 
     stub = WebMock.stub(:post, "https://slack.com/api/chat.postMessage?token=some_token&text=something+important&channel=general")
-                  .to_return(body: json)
+      .to_return(body: json)
 
     api.post_message(text: "something important", channel: "general")
 

--- a/src/slack/api.cr
+++ b/src/slack/api.cr
@@ -12,7 +12,7 @@ class Slack::API
   end
 
   def channel_info(channel_id)
-    get_json "/api/conversations.info", "channel", Channel, { "channel" => channel_id }
+    get_json "/api/conversations.info", "channel", Channel, {"channel" => channel_id}
   end
 
   def post_message(text : String, channel : String)
@@ -41,7 +41,7 @@ class Slack::API
   private def get_json(url, field, klass, params = {} of String => String)
     encoded_params = HTTP::Params.build do |form|
       form.add "token", @token
-      params.each do |(k,v)|
+      params.each do |(k, v)|
         form.add k, v
       end
     end
@@ -103,7 +103,7 @@ class Slack::API
     end
 
     if ts && channel
-      { timestamp: ts.not_nil!, channel: channel.not_nil! }
+      {timestamp: ts.not_nil!, channel: channel.not_nil!}
     else
       raise Error.new(error.not_nil!)
     end

--- a/src/slack/api/channel.cr
+++ b/src/slack/api/channel.cr
@@ -1,21 +1,21 @@
 class Slack::API::Channel
-  JSON.mapping({
-    id:          String,
-    name:        String,
-    created:     Int64,
-    creator:     String,
-    is_archived: Bool,
-    is_member:   Bool,
-    num_members: {type: Int32, nilable: true},
-    topic:       Topic,
-    purpose:     Topic,
-  })
+  include JSON::Serializable
+
+  property id : String
+  property name : String
+  property created : Int64
+  property creator : String
+  property is_archived : Bool
+  property is_member : Bool
+  property num_members : Int32?
+  property topic : Topic
+  property purpose : Topic
 
   struct Topic
-    JSON.mapping({
-      value:    String,
-      creator:  String,
-      last_set: Int64,
-    })
+    include JSON::Serializable
+
+    property value : String
+    property creator : String
+    property last_set : Int64
   end
 end

--- a/src/slack/api/user.cr
+++ b/src/slack/api/user.cr
@@ -1,38 +1,38 @@
 class Slack::API::User
-  JSON.mapping({
-    id:                  String,
-    name:                String,
-    deleted:             Bool,
-    color:               {type: String, nilable: true},
-    profile:             Profile,
-    is_admin:            {type: Bool, nilable: true},
-    is_owner:            {type: Bool, nilable: true},
-    is_primary_owner:    {type: Bool, nilable: true},
-    is_restricted:       {type: Bool, nilable: true},
-    is_ultra_restricted: {type: Bool, nilable: true},
-    has_2fa:             {type: Bool, nilable: true},
-    has_files:           {type: Bool, nilable: true},
-  })
+  include JSON::Serializable
 
-  def initialize(@id, @name, @deleted, @profile)
+  property id : String
+  property name : String
+  property deleted : Bool
+  property color : String?
+  property profile : Profile
+  property is_admin : Bool?
+  property is_owner : Bool?
+  property is_primary_owner : Bool?
+  property is_restricted : Bool?
+  property is_ultra_restricted : Bool?
+  property has_2fa : Bool?
+  property has_files : Bool?
+
+  def initialize(@id : String, @name : String, @deleted : Bool, @profile : Profile)
   end
 
   class Profile
-    JSON.mapping({
-      first_name: {type: String, nilable: true},
-      last_name:  {type: String, nilable: true},
-      real_name:  String,
-      email:      {type: String, nilable: true},
-      skype:      {type: String, nilable: true},
-      phone:      {type: String, nilable: true},
-      image_24:   {type: String, nilable: true},
-      image_32:   {type: String, nilable: true},
-      image_48:   {type: String, nilable: true},
-      image_72:   {type: String, nilable: true},
-      image_192:  {type: String, nilable: true},
-    })
+    include JSON::Serializable
 
-    def initialize(@real_name, @email = nil)
+    property first_name : String?
+    property last_name : String?
+    property real_name : String
+    property email : String?
+    property skype : String?
+    property phone : String?
+    property image_24 : String?
+    property image_32 : String?
+    property image_48 : String?
+    property image_72 : String?
+    property image_192 : String?
+
+    def initialize(@real_name : String, @email : String? = nil)
     end
   end
 end

--- a/src/slack/message.cr
+++ b/src/slack/message.cr
@@ -1,19 +1,21 @@
 require "json"
 
 class Slack::Message
-  JSON.mapping({
-    text:             String,
-    channel:          {type: String, nilable: true},
-    icon_emoji:       {type: String, nilable: true},
-    icon_url:         {type: String, nilable: true},
-    username:         {type: String, nilable: true},
-    attachments:      {type: Array(JSON::Any), nilable: true},
-    response_type:    {type: String, nilable: true},
-    delete_original:  {type: Bool, nilable: true},
-    replace_original: {type: Bool, nilable: true},
-  })
+  include JSON::Serializable
 
-  def initialize(@text : String, @channel = nil, @icon_emoji = nil, @icon_url = nil, @username = nil, @attachments = nil, @response_type = nil, @delete_original = nil, @replace_original = nil)
+  property text : String
+  property channel : String?
+  property icon_emoji : String?
+  property icon_url : String?
+  property username : String?
+  property attachments : Array(JSON::Any)?
+  property response_type : String?
+  property delete_original : Bool?
+  property replace_original : Bool?
+
+  def initialize(@text : String, @channel : String? = nil, @icon_emoji : String? = nil,
+                 @icon_url : String? = nil, @username : String? = nil, @attachments : Array(JSON::Any)? = nil,
+                 @response_type : String? = nil, @delete_original : Bool? = nil, @replace_original : Bool? = nil)
   end
 
   def token=(token)


### PR DESCRIPTION
Fixes #8 
Fixes #10 

I ran the specs locally against 0.36.1 and 1.0.0. I tried to run against 0.35.1, but webmock throws some errors, so I set the version to a minimum of 0.36.1.

I also ran the formatter tool, so a few things shifted around.