### PR TITLE
Support OAuth2 session auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ api.post_message(message)
 More complex messages are supported. Please check the Message class.
 You can also get the users and channels given an token.
 
+
+If you wish to configure the upstream slack host, you may do so
+
+```crystal
+require "slack"
+
+Slack::API.slack_host = "enterprise.slack.com" # Defaults to "slack.com"
+```
+
 ## Todo
 
 Lots of API methods are missing!

--- a/spec/api_spec.cr
+++ b/spec/api_spec.cr
@@ -4,209 +4,211 @@ describe Slack::API do
   it "gets users" do
     api = Slack::API.new "some_token"
 
-    json = %({
-                "id": "U023BECGF",
-                "name": "bobby",
-                "deleted": false,
-                "color": "9f69e7",
-                "profile": {
-                    "first_name": "Bobby",
-                    "last_name": "Tables",
-                    "real_name": "Bobby Tables",
-                    "email": "bobby@slack.com",
-                    "skype": "my-skype-name",
-                    "phone": "+1 (123) 456 7890",
-                    "image_24": "image_24_1",
-                    "image_32": "image_32_1",
-                    "image_48": "image_48_1",
-                    "image_72": "image_72_1",
-                    "image_192": "image_192_1"
-                },
-                "is_admin": true,
-                "is_owner": true,
-                "has_2fa": false,
-                "has_files": true
-            })
+    data = {
+      "id" => "U023BECGF",
+      "name" => "bobby",
+      "deleted" => false,
+      "color" => "9f69e7",
+      "profile" => {
+        "first_name" => "Bobby",
+        "last_name" => "Tables",
+        "real_name" => "Bobby Tables",
+        "email" => "bobby@slack.com",
+        "skype" => "my-skype-name",
+        "phone" => "+1 (123) 456 7890",
+        "image_24" => "image_24_1",
+        "image_32" => "image_32_1",
+        "image_48" => "image_48_1",
+        "image_72" => "image_72_1",
+        "image_192" => "image_192_1"
+      },
+      "is_admin" => true,
+      "is_owner" => true,
+      "has_2fa" => false,
+      "has_files" => true
+    }
 
-    WebMock.stub(:get, "https://slack.com/api/users.list?token=some_token")
-      .to_return(body: %({
-          "ok": true,
-          "members": [#{json}]
-        }))
+    WebMock
+      .stub(:get, "https://slack.com/api/users.list?")
+      .with(headers: { "Authorization" => "Bearer some_token" })
+      .to_return(body: { "ok" => true, "members" => [data] }.to_json)
 
     users = api.users
     users.size.should eq(1)
 
     user = users[0]
-    JSON.parse(user.to_json).should eq(JSON.parse(json))
+    JSON.parse(user.to_json).should eq(data)
   end
 
   it "gets channels" do
     api = Slack::API.new "some_token"
 
-    json = %({
-      "id": "C012AB3CD",
-      "name": "general",
-      "is_channel": true,
-      "is_group": false,
-      "is_im": false,
-      "created": 1449252889,
-      "creator": "U012A3CDE",
-      "is_archived": false,
-      "is_general": true,
-      "unlinked": 0,
-      "name_normalized": "general",
-      "is_shared": false,
-      "is_ext_shared": false,
-      "is_org_shared": false,
-      "pending_shared": [],
-      "is_pending_ext_shared": false,
-      "is_member": true,
-      "is_private": false,
-      "is_mpim": false,
-      "topic": {
-          "value": "Company-wide announcements and work-based matters",
-          "creator": "",
-          "last_set": 0
+    data = {
+      "id" => "C012AB3CD",
+      "name" => "general",
+      "is_channel" => true,
+      "is_group" => false,
+      "is_im" => false,
+      "created" => 1449252889,
+      "creator" => "U012A3CDE",
+      "is_archived" => false,
+      "is_general" => true,
+      "unlinked" => 0,
+      "name_normalized" => "general",
+      "is_shared" => false,
+      "is_ext_shared" => false,
+      "is_org_shared" => false,
+      "pending_shared" => [] of String,
+      "is_pending_ext_shared" => false,
+      "is_member" => true,
+      "is_private" => false,
+      "is_mpim" => false,
+      "topic" => {
+        "value" => "Company-wide announcements and work-based matters",
+        "creator" => "",
+        "last_set" => 0
       },
-      "purpose": {
-          "value": "This channel is for team-wide communication and announcements. All team members are in this channel.",
-          "creator": "",
-          "last_set": 0
+      "purpose" => {
+        "value" => "This channel is for team-wide communication and announcements. All team members are in this channel.",
+        "creator" => "",
+        "last_set" => 0
       },
-      "previous_names": [],
-      "num_members": 4
-    })
+      "previous_names" => [] of String,
+      "num_members" => 4
+    }
 
-    relevant_fields_json = %({
-      "id": "C012AB3CD",
-      "name": "general",
-      "created": 1449252889,
-      "creator": "U012A3CDE",
-      "is_archived": false,
-      "is_member": true,
-      "num_members": 4,
-      "topic": {
-          "value": "Company-wide announcements and work-based matters",
-          "creator": "",
-          "last_set": 0
+    relevant_fields = {
+      "id" => "C012AB3CD",
+      "name" => "general",
+      "created" => 1449252889,
+      "creator" => "U012A3CDE",
+      "is_archived" => false,
+      "is_member" => true,
+      "num_members" => 4,
+      "topic" => {
+        "value" => "Company-wide announcements and work-based matters",
+        "creator" => "",
+        "last_set" => 0
       },
-      "purpose": {
-          "value": "This channel is for team-wide communication and announcements. All team members are in this channel.",
-          "creator": "",
-          "last_set": 0
+      "purpose" => {
+        "value" => "This channel is for team-wide communication and announcements. All team members are in this channel.",
+        "creator" => "",
+        "last_set" => 0
       }
-    })
+    }
 
-    WebMock.stub(:get, "https://slack.com/api/conversations.list?token=some_token")
-      .to_return(body: %({
-          "ok": true,
-          "channels": [#{json}],
-          "response_metadata": {
-            "next_cursor": "dGVhbTpDMDYxRkE1UEI="
-          }
-        }))
+    WebMock
+      .stub(:get, "https://slack.com/api/conversations.list?")
+      .with(headers: { "Authorization" => "Bearer some_token" })
+      .to_return(body: {
+        "ok" => true,
+        "channels" => [data],
+        "response_metadata" => {
+          "next_cursor" => "dGVhbTpDMDYxRkE1UEI="
+        }
+      }.to_json)
 
     channels = api.channels
     channels.size.should eq(1)
 
     channel = channels[0]
-    JSON.parse(channel.to_json).should eq(JSON.parse(relevant_fields_json))
+    JSON.parse(channel.to_json).should eq(relevant_fields)
   end
 
   it "gets a channel's details" do
     api = Slack::API.new "some_token"
 
-    json = %({
-      "id": "C012AB3CD",
-      "name": "general",
-      "is_channel": true,
-      "is_group": false,
-      "is_im": false,
-      "created": 1449252889,
-      "creator": "W012A3BCD",
-      "is_archived": false,
-      "is_general": true,
-      "unlinked": 0,
-      "name_normalized": "general",
-      "is_read_only": false,
-      "is_shared": false,
-      "parent_conversation": null,
-      "is_ext_shared": false,
-      "is_org_shared": false,
-      "pending_shared": [],
-      "is_pending_ext_shared": false,
-      "is_member": true,
-      "is_private": false,
-      "is_mpim": false,
-      "last_read": "1502126650.228446",
-      "topic": {
-          "value": "For public discussion of generalities",
-          "creator": "W012A3BCD",
-          "last_set": 1449709364
+    data = {
+      "id" => "C012AB3CD",
+      "name" => "general",
+      "is_channel" => true,
+      "is_group" => false,
+      "is_im" => false,
+      "created" => 1449252889,
+      "creator" => "W012A3BCD",
+      "is_archived" => false,
+      "is_general" => true,
+      "unlinked" => 0,
+      "name_normalized" => "general",
+      "is_read_only" => false,
+      "is_shared" => false,
+      "parent_conversation" => nil,
+      "is_ext_shared" => false,
+      "is_org_shared" => false,
+      "pending_shared" => [] of String,
+      "is_pending_ext_shared" => false,
+      "is_member" => true,
+      "is_private" => false,
+      "is_mpim" => false,
+      "last_read" => "1502126650.228446",
+      "topic" => {
+        "value" => "For public discussion of generalities",
+        "creator" => "W012A3BCD",
+        "last_set" => 1449709364
       },
-      "purpose": {
-          "value": "This part of the workspace is for fun. Make fun here.",
-          "creator": "W012A3BCD",
-          "last_set": 1449709364
+      "purpose" => {
+        "value" => "This part of the workspace is for fun. Make fun here.",
+        "creator" => "W012A3BCD",
+        "last_set" => 1449709364
       },
-      "previous_names": [
-          "specifics",
-          "abstractions",
-          "etc"
+      "previous_names" => [
+        "specifics",
+        "abstractions",
+        "etc"
       ],
-      "locale": "en-US"
-    })
+      "locale" => "en-US"
+    }
 
-    relevant_fields_json = %({
-      "id": "C012AB3CD",
-      "name": "general",
-      "created": 1449252889,
-      "creator": "W012A3BCD",
-      "is_archived": false,
-      "is_member": true,
-      "topic": {
-          "value": "For public discussion of generalities",
-          "creator": "W012A3BCD",
-          "last_set": 1449709364
+    relevant_fields = {
+      "id" => "C012AB3CD",
+      "name" => "general",
+      "created" => 1449252889,
+      "creator" => "W012A3BCD",
+      "is_archived" => false,
+      "is_member" => true,
+      "topic" => {
+        "value" => "For public discussion of generalities",
+        "creator" => "W012A3BCD",
+        "last_set" => 1449709364
       },
-      "purpose": {
-          "value": "This part of the workspace is for fun. Make fun here.",
-          "creator": "W012A3BCD",
-          "last_set": 1449709364
+      "purpose" => {
+        "value" => "This part of the workspace is for fun. Make fun here.",
+        "creator" => "W012A3BCD",
+        "last_set" => 1449709364
       }
-    })
+    }
 
-    WebMock.stub(:get, "https://slack.com/api/conversations.info?token=some_token&channel=C012AB3CD")
-      .to_return(body: %({
-          "ok": true,
-          "channel": #{json}
-        }))
+    WebMock
+      .stub(:get, "https://slack.com/api/conversations.info?channel=C012AB3CD")
+      .with(headers: { "Authorization" => "Bearer some_token" })
+      .to_return(body: { "ok" => true, "channel" => data }.to_json)
 
     channel = api.channel_info("C012AB3CD")
 
-    JSON.parse(channel.to_json).should eq(JSON.parse(relevant_fields_json))
+    JSON.parse(channel.to_json).should eq(relevant_fields)
   end
 
   it "posts to a channel" do
     api = Slack::API.new "some_token"
 
-    json = %({
-      "ok": true,
-      "channel": "C1PJMB3MI",
-      "ts": "1468419247.000010",
-      "message": {
-        "text": "something important",
-        "username": "the bot",
-        "bot_id": "B1R4VQ5RU",
-        "type": "message",
-        "subtype": "bot_message",
-        "ts": "1468419247.000010"
+    data = {
+      "ok" => true,
+      "channel" => "C1PJMB3MI",
+      "ts" => "1468419247.000010",
+      "message" => {
+        "text" => "something important",
+        "username" => "the bot",
+        "bot_id" => "B1R4VQ5RU",
+        "type" => "message",
+        "subtype" => "bot_message",
+        "ts" => "1468419247.000010"
       }
-    })
+    }
 
-    stub = WebMock.stub(:post, "https://slack.com/api/chat.postMessage?token=some_token&text=something+important&channel=general")
-      .to_return(body: json)
+    stub = WebMock
+      .stub(:post, "https://slack.com/api/chat.postMessage?text=something+important&channel=general")
+      .with(headers: { "Authorization" => "Bearer some_token" })
+      .to_return(body: data.to_json)
 
     api.post_message(text: "something important", channel: "general")
 
@@ -216,7 +218,10 @@ describe Slack::API do
   it "raises if posting to a channel failed" do
     api = Slack::API.new "some_token"
 
-    stub = WebMock.stub(:post, "https://slack.com/api/chat.postMessage?token=some_token&text=something+important&channel=general").to_return(status: 400)
+    stub = WebMock
+      .stub(:post, "https://slack.com/api/chat.postMessage?text=something+important&channel=general")
+      .with(headers: { "Authorization" => "Bearer some_token" })
+      .to_return(status: 400)
 
     expect_raises(Slack::API::Error) do
       api.post_message(text: "something important", channel: "general")

--- a/spec/message_spec.cr
+++ b/spec/message_spec.cr
@@ -15,8 +15,12 @@ describe Slack::Message do
     message.icon_url.should eq("some_url")
     message.username.should eq("some_username")
 
-    stub = WebMock.stub(:post, "slack.com/")
-      .with(body: "payload=%7B%22text%22:%22some_text%22,%22channel%22:%22some_channel%22,%22icon_emoji%22:%22some_emoji%22,%22icon_url%22:%22some_url%22,%22username%22:%22some_username%22%7D", headers: {"Content-type" => "application/x-www-form-urlencoded"})
+    stub = WebMock
+      .stub(:post, "slack.com/")
+      .with(
+        body: "payload=%7B%22text%22%3A%22some_text%22%2C%22channel%22%3A%22some_channel%22%2C%22icon_emoji%22%3A%22some_emoji%22%2C%22icon_url%22%3A%22some_url%22%2C%22username%22%3A%22some_username%22%7D",
+        headers: {"Content-type" => "application/x-www-form-urlencoded"}
+      )
 
     message.send_to_hook("http://slack.com")
     stub.calls.should eq(1)
@@ -38,8 +42,12 @@ describe Slack::Message do
     message.username.should eq("some_username")
     message.attachments.not_nil!.size.should eq(2)
 
-    stub = WebMock.stub(:post, "slack.com/")
-      .with(body: "payload=%7B%22text%22:%22some_text%22,%22channel%22:%22some_channel%22,%22username%22:%22some_username%22,%22attachments%22:[%7B%22foo%22:%22bar%22,%22baz%22:123%7D,%7B%22something%22:[%22else%22]%7D]%7D", headers: {"Content-type" => "application/x-www-form-urlencoded"})
+    stub = WebMock
+      .stub(:post, "slack.com/")
+      .with(
+        body: "payload=%7B%22text%22%3A%22some_text%22%2C%22channel%22%3A%22some_channel%22%2C%22username%22%3A%22some_username%22%2C%22attachments%22%3A%5B%7B%22foo%22%3A%22bar%22%2C%22baz%22%3A123%7D%2C%7B%22something%22%3A%5B%22else%22%5D%7D%5D%7D",
+        headers: {"Content-type" => "application/x-www-form-urlencoded"}
+      )
 
     message.send_to_hook("http://slack.com")
     stub.calls.should eq(1)

--- a/spec/slash_command_spec.cr
+++ b/spec/slash_command_spec.cr
@@ -2,8 +2,18 @@ require "./spec_helper"
 
 describe Slack::SlashCommand do
   it "creates from HTTP::Request" do
-    request = HTTP::Request.new "POST", "/",
-      body: "token=some_token&team_id=0&channel_id=1&channel_name=some_channel&user_id=2&user_name=some_user&command=cmd&text=txt&response_url=#{URI.encode("http://slack.com/response")}"
+    body = URI::Params.encode({
+      token: "some_token",
+      team_id: "0",
+      channel_id: "1",
+      channel_name: "some_channel",
+      user_id: "2",
+      user_name: "some_user",
+      command: "cmd",
+      text: "txt",
+      response_url: "http://slack.com/response"
+    })
+    request = HTTP::Request.new("POST", "/", body: body)
 
     command = Slack::SlashCommand.from_request(request)
     command.token.should eq("some_token")
@@ -18,7 +28,17 @@ describe Slack::SlashCommand do
   end
 
   it "creates from request body" do
-    body = "token=some_token&team_id=0&channel_id=1&channel_name=some_channel&user_id=2&user_name=some_user&command=cmd&text=txt&response_url=#{URI.encode("http://slack.com/response")}"
+    body = URI::Params.encode({
+      token: "some_token",
+      team_id: "0",
+      channel_id: "1",
+      channel_name: "some_channel",
+      user_id: "2",
+      user_name: "some_user",
+      command: "cmd",
+      text: "txt",
+      response_url: "http://slack.com/response"
+    })
 
     command = Slack::SlashCommand.from_request_body(body)
     command.token.should eq("some_token")

--- a/src/slack/api.cr
+++ b/src/slack/api.cr
@@ -7,14 +7,13 @@ class Slack::API
 
   class_property slack_host : String = "slack.com"
 
-  # NOTE: deprecated
   def initialize(@token : String)
     @client = HTTP::Client.new self.class.slack_host, tls: true
   end
 
   def initialize(@oauth_session : OAuth2::Session)
     @client = HTTP::Client.new self.class.slack_host, tls: true
-    @oauth_session.access_token.authenticate(@client)
+    oauth_session.access_token.authenticate(@client)
   end
 
   def users

--- a/src/slack/api.cr
+++ b/src/slack/api.cr
@@ -58,7 +58,7 @@ class Slack::API
     end
 
     response = @mutex.synchronize do
-      @client.get("GET", "#{url}?#{encoded_params}", headers: authenticated_headers)
+      @client.get("#{url}?#{encoded_params}", headers: authenticated_headers)
     end
 
     handle(response) do

--- a/src/slack/api.cr
+++ b/src/slack/api.cr
@@ -34,8 +34,6 @@ class Slack::API
 
   def post_message(message : Message)
     params = HTTP::Params.build do |form|
-      form.add "token", @token unless @token.empty?
-
       message.add_params(form)
     end
 
@@ -44,7 +42,6 @@ class Slack::API
 
   def update_message(message : Message, timestamp : String)
     encoded_params = HTTP::Params.build do |form|
-      form.add "token", @token unless @token.empty?
       form.add "ts", timestamp
       message.add_params(form)
     end
@@ -54,7 +51,6 @@ class Slack::API
 
   private def get_json(url, field, klass, params = {} of String => String)
     encoded_params = HTTP::Params.build do |form|
-      form.add "token", @token
       params.each do |(k, v)|
         form.add k, v
       end

--- a/src/slack/message.cr
+++ b/src/slack/message.cr
@@ -23,7 +23,7 @@ class Slack::Message
   end
 
   def send_to_hook(url)
-    HTTP::Client.post(url, form: "payload=#{URI.encode to_json}")
+    HTTP::Client.post(url, form: URI::Params.encode({ payload: to_json }))
   end
 
   def post_with_api(api)


### PR DESCRIPTION
Implements OAuth2 authenticated HTTP Clients for the Slack API.

Originally authored by @HertzDevil 

Additionally, the upstream host for the Slack API may be configured via the `Slack::API.slack_host` property.

Closes #14 
Closes #15 